### PR TITLE
Expose CBPeripheral by UUID

### DIFF
--- a/Sources/CombineBluetooth/Internal/CoreBluetoothCentralManager.swift
+++ b/Sources/CombineBluetooth/Internal/CoreBluetoothCentralManager.swift
@@ -51,6 +51,13 @@ extension CoreBluetoothCentralManager: CentralManager {
         return newInstance
     }
 
+    public func peripheral(for uuid: UUID) -> CBPeripheral? {
+        cachedPeripheralsAccess.lock()
+        defer { cachedPeripheralsAccess.unlock() }
+        if let instance = cachedPeripherals[uuid] { return instance.peripheral }
+        return nil
+    }
+
     var isScanning: AnyPublisher<Bool, Never> {
         centralManager
             .publisher(for: \.isScanning)

--- a/Sources/CombineBluetooth/Models/CentralManager.swift
+++ b/Sources/CombineBluetooth/Models/CentralManager.swift
@@ -13,6 +13,7 @@ public protocol CentralManager: BluetoothManager {
     func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBUUID]) -> [BluetoothPeripheral]
     func connect(_ peripheral: BluetoothPeripheral) -> AnyPublisher<BluetoothPeripheral, BluetoothError>
     func connect(_ peripheral: BluetoothPeripheral, options: [String : Any]) -> AnyPublisher<BluetoothPeripheral, BluetoothError>
+    func peripheral(for uuid: UUID) -> CBPeripheral?
     // TODO: Nice to have, but complicate to handle single delegate (subscribing again with different options should end prior observations, which can
     //       be a bit unexpected).
     // - (void)registerForConnectionEventsWithOptions:(nullable NSDictionary<CBConnectionEventMatchingOption, id> *)options NS_AVAILABLE_IOS(13_0);


### PR DESCRIPTION
Useful in case it’s needed to hand out the peripheral to code that requires direct access.