### PR TITLE
Peripheral delegation

### DIFF
--- a/Sources/CombineBluetooth/Internal/CoreBluetoothCentralManager.swift
+++ b/Sources/CombineBluetooth/Internal/CoreBluetoothCentralManager.swift
@@ -51,10 +51,10 @@ extension CoreBluetoothCentralManager: CentralManager {
         return newInstance
     }
 
-    public func peripheral(for uuid: UUID) -> CBPeripheral? {
+    public func peripheral(for uuid: UUID) -> BluetoothPeripheral? {
         cachedPeripheralsAccess.lock()
         defer { cachedPeripheralsAccess.unlock() }
-        if let instance = cachedPeripherals[uuid] { return instance.peripheral }
+        if let instance = cachedPeripherals[uuid] { return instance }
         return nil
     }
 

--- a/Sources/CombineBluetooth/Internal/CoreBluetoothPeripheral.swift
+++ b/Sources/CombineBluetooth/Internal/CoreBluetoothPeripheral.swift
@@ -26,44 +26,69 @@ class CoreBluetoothPeripheral: NSObject, Identifiable {
         super.init()
         self.peripheral.delegate = self
     }
+    
+    var proxyDelegate: CBPeripheralDelegate?
 }
 
 extension CoreBluetoothPeripheral: CBPeripheralDelegate {
     func peripheralDidUpdateName(_ peripheral: CBPeripheral) { }
+    
     func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) { }
+    
     func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
         didReadRSSI.send(error.map(Result.failure) ?? .success(RSSI))
+        proxyDelegate?.peripheral?(peripheral, didReadRSSI: RSSI, error: error)
     }
+    
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         didDiscoverServices.send(error.map(Result.failure) ?? .success(peripheral.services ?? []))
+        proxyDelegate?.peripheral?(peripheral, didDiscoverServices: error)
     }
     func peripheral(_ peripheral: CBPeripheral, didDiscoverIncludedServicesFor service: CBService, error: Error?) {
         didDiscoverIncludedServices.send(error.map(Result.failure) ?? .success((parent: service, included: service.includedServices ?? [])))
+        proxyDelegate?.peripheral?(peripheral, didDiscoverIncludedServicesFor: service, error: error)
     }
+    
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
         didDiscoverCharacteristics.send(error.map(Result.failure) ?? .success((service: service, characteristics: service.characteristics ?? [])))
+        proxyDelegate?.peripheral?(peripheral, didDiscoverCharacteristicsFor: service, error: error)
     }
+    
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         readValueForCharacteristic.send(error.map(Result.failure) ?? .success(characteristic))
+        proxyDelegate?.peripheral?(peripheral, didUpdateValueFor: characteristic, error: error)
     }
+    
     func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
         didWriteValueForCharacteristic.send(error.map(Result.failure) ?? .success(characteristic))
+        proxyDelegate?.peripheral?(peripheral, didWriteValueFor: characteristic, error: error)
     }
+    
     func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
         didUpdateNotificationStateForCharacteristic.send(error.map(Result.failure) ?? .success(characteristic))
+        proxyDelegate?.peripheral?(peripheral, didUpdateNotificationStateFor: characteristic, error: error)
     }
+    
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor descriptor: CBDescriptor, error: Error?) {
         readValueForDescriptor.send(error.map(Result.failure) ?? .success(descriptor))
+        proxyDelegate?.peripheral?(peripheral, didUpdateValueFor: descriptor, error: error)
     }
+    
     func peripheral(_ peripheral: CBPeripheral, didDiscoverDescriptorsFor characteristic: CBCharacteristic, error: Error?) {
         didDiscoverDescriptors.send(error.map(Result.failure) ?? .success((characteristic: characteristic, descriptors: characteristic.descriptors ?? [])))
+        proxyDelegate?.peripheral?(peripheral, didDiscoverDescriptorsFor: characteristic, error: error)
     }
+    
     func peripheral(_ peripheral: CBPeripheral, didWriteValueFor descriptor: CBDescriptor, error: Error?) {
         didWriteValueForDescriptor.send(error.map(Result.failure) ?? .success(descriptor))
+        proxyDelegate?.peripheral?(peripheral, didWriteValueFor: descriptor, error: error)
     }
+    
     func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
         becameReadyForWriteWithoutResponse.send(())
+        proxyDelegate?.peripheralIsReady?(toSendWriteWithoutResponse: peripheral)
     }
+    
     func peripheral(_ peripheral: CBPeripheral, didOpen channel: CBL2CAPChannel?, error: Error?) {
         didOpenChannel.send(
             error.map(Result.failure)
@@ -74,6 +99,7 @@ extension CoreBluetoothPeripheral: CBPeripheralDelegate {
                     userInfo: nil
                 ))
         )
+        proxyDelegate?.peripheral?(peripheral, didOpen: channel, error: error)
     }
 }
 

--- a/Sources/CombineBluetooth/Models/BluetoothPeripheral.swift
+++ b/Sources/CombineBluetooth/Models/BluetoothPeripheral.swift
@@ -9,6 +9,7 @@ public protocol BluetoothPeripheral: BluetoothPeer {
     var services: [BluetoothService]? { get }
     var canSendWriteWithoutResponse: Bool { get }
     var isReadyAgainForWriteWithoutResponse: AnyPublisher<Void, Never> { get }
+    var proxyDelegate: CBPeripheralDelegate? { get set }
     func readRSSI() -> AnyPublisher<NSNumber, BluetoothError>
     func discoverServices(_ serviceUUIDs: [CBUUID]?) -> AnyPublisher<BluetoothService, BluetoothError>
     func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for service: BluetoothService) -> AnyPublisher<BluetoothService, BluetoothError>

--- a/Sources/CombineBluetooth/Models/CentralManager.swift
+++ b/Sources/CombineBluetooth/Models/CentralManager.swift
@@ -13,7 +13,7 @@ public protocol CentralManager: BluetoothManager {
     func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBUUID]) -> [BluetoothPeripheral]
     func connect(_ peripheral: BluetoothPeripheral) -> AnyPublisher<BluetoothPeripheral, BluetoothError>
     func connect(_ peripheral: BluetoothPeripheral, options: [String : Any]) -> AnyPublisher<BluetoothPeripheral, BluetoothError>
-    func peripheral(for uuid: UUID) -> CBPeripheral?
+    func peripheral(for uuid: UUID) -> BluetoothPeripheral?
     // TODO: Nice to have, but complicate to handle single delegate (subscribing again with different options should end prior observations, which can
     //       be a bit unexpected).
     // - (void)registerForConnectionEventsWithOptions:(nullable NSDictionary<CBConnectionEventMatchingOption, id> *)options NS_AVAILABLE_IOS(13_0);


### PR DESCRIPTION
Adds ability to proxy delegate peripheral manager functions to be able to make use of them outside of provided publishers and api.